### PR TITLE
remove unused rails stuff

### DIFF
--- a/app/helpers/openstax/swagger/application_helper.rb
+++ b/app/helpers/openstax/swagger/application_helper.rb
@@ -1,4 +1,0 @@
-module OpenStax::Swagger
-  module ApplicationHelper
-  end
-end

--- a/app/models/openstax/swagger/application_record.rb
+++ b/app/models/openstax/swagger/application_record.rb
@@ -1,5 +1,0 @@
-module OpenStax::Swagger
-  class ApplicationRecord < ActiveRecord::Base
-    self.abstract_class = true
-  end
-end


### PR DESCRIPTION
There is probably other unused stuff, but the activerecord one was causing problems in sites without activerecord