### PR TITLE
Add swagger_path wrapper to generate swagger_schema too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+language: ruby
+rvm:
+  - "2.3.7"
+cache: bundler
+bundler_args: --retry=6
+script:
+  - bundle exec rspec
+notifications:
+  email: false
+before_install:
+  - gem install bundler

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ $ gem install openstax_swagger
 
 ## Generating client libraries
 
-
-
 ```ruby
 OpenStax::Swagger.configure do |config|
   config.client_language_configs = {
@@ -52,6 +50,16 @@ OpenStax::Swagger.configure do |config|
   }
 end
 ```
+
+## Extensions
+
+### bind
+
+...
+
+### `swagger_path_and_parameters_schema`
+
+`swagger_path_and_parameters_schema` has the same arguments as the native `swagger_path` method but in addition to generating a swagger path definition, it will also call `swagger_schema` on the query parameters to let developers generate a binding from this schema to bind to parameters in a controller call (i.e. they can let swagger-codegen generate code that will validate the incoming parameters instead of replicating validity checks in the schema and in the controller).
 
 ## Contributing
 Contribution directions go here.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ end
 
 ### `swagger_path_and_parameters_schema`
 
-`swagger_path_and_parameters_schema` has the same arguments as the native `swagger_path` method but in addition to generating a swagger path definition, it will also call `swagger_schema` on the query parameters to let developers generate a binding from this schema to bind to parameters in a controller call (i.e. they can let swagger-codegen generate code that will validate the incoming parameters instead of replicating validity checks in the schema and in the controller).
+`swagger_path_and_parameters_schema` has the same arguments as the native `swagger_path` method but in addition to generating a swagger path definition, it will also call `swagger_schema` on the query parameters to let developers generate a binding from this schema to bind to parameters in a controller call (i.e. they can let swagger-codegen generate code that will validate the incoming parameters instead of replicating validity checks in the schema and in the controller).  Probably only works for simple parameters, not parameters with nested schemas.
 
 ## Contributing
 Contribution directions go here.

--- a/lib/openstax/swagger/swagger_blocks_extensions.rb
+++ b/lib/openstax/swagger/swagger_blocks_extensions.rb
@@ -21,7 +21,7 @@ module OpenStax::Swagger::SwaggerBlocksExtensions
           raise "Must set an operationId when generating a binding from a swagger_path"
         end
 
-        binding_name = path_node.data[:operationId].camelcase
+        binding_name = path_node.data[:operationId].camelcase + "Parameters"
         required_keys = []
 
         swagger_schema binding_name do

--- a/lib/openstax/swagger/swagger_blocks_extensions.rb
+++ b/lib/openstax/swagger/swagger_blocks_extensions.rb
@@ -13,19 +13,29 @@ module OpenStax::Swagger::SwaggerBlocksExtensions
       end
     end
 
-    # Same as call to `swagger_path` but also generates a `swagger_model` for the parameters
+    # Same as call to `swagger_path` but also generates a `swagger_schema` for the parameters
     # so that controller code can bind the parameters to a binding.
-    def swagger_path_and_parameters_model(path, &block)
+    def swagger_path_and_parameters_schema(path, &block)
       swagger_path(path, &block).tap do |path_node|
-        if path_node.data[:operationId].blank?
+        # When this is the first call against this `path`, the path_node is a `PathNode`
+        # wrapping one `OperationNode`.  Afterwards it is an `OperationNode`.  This case
+        # makes sure we are always dealing with the OperationNode.
+        data = case path_node
+        when Swagger::Blocks::Nodes::PathNode
+          path_node.data[path_node.data.keys.first].data
+        when Swagger::Blocks::Nodes::OperationNode
+          path_node.data
+        end
+
+        if data[:operationId].blank?
           raise "Must set an operationId when generating a binding from a swagger_path"
         end
 
-        binding_name = path_node.data[:operationId].camelcase + "Parameters"
+        binding_name = data[:operationId].camelcase + "Parameters"
         required_keys = []
 
         swagger_schema binding_name do
-          path_node.data[:parameters].map(&:data).each do |parameter_hash|
+          data[:parameters].map(&:data).each do |parameter_hash|
             parameter_hash.symbolize_keys!
             required_keys.push(parameter_hash[:name]) if parameter_hash.delete(:required)
             property parameter_hash[:name] do

--- a/lib/openstax/swagger/swagger_blocks_extensions.rb
+++ b/lib/openstax/swagger/swagger_blocks_extensions.rb
@@ -12,6 +12,32 @@ module OpenStax::Swagger::SwaggerBlocksExtensions
         end
       end
     end
+
+    # Same as call to `swagger_path` but also generates a `swagger_model` for the parameters
+    # so that controller code can bind the parameters to a binding.
+    def swagger_path_and_parameters_model(path, &block)
+      swagger_path(path, &block).tap do |path_node|
+        if path_node.data[:operationId].blank?
+          raise "Must set an operationId when generating a binding from a swagger_path"
+        end
+
+        binding_name = path_node.data[:operationId].camelcase
+        required_keys = []
+
+        swagger_schema binding_name do
+          path_node.data[:parameters].map(&:data).each do |parameter_hash|
+            parameter_hash.symbolize_keys!
+            required_keys.push(parameter_hash[:name]) if parameter_hash.delete(:required)
+            property parameter_hash[:name] do
+              parameter_hash.except(:in, :name).each do |key, value|
+                key key, value
+              end
+            end
+          end
+          key :required, required_keys
+        end
+      end
+    end
   end
 
 end

--- a/spec/lib/swagger_path_and_parameters_schema_spec.rb
+++ b/spec/lib/swagger_path_and_parameters_schema_spec.rb
@@ -2,8 +2,31 @@ require 'rails_helper'
 
 RSpec.describe 'swagger_path_and_parameters_schema' do
 
-  it 'generates the path and parameters definition' do
-    json = Swagger::Blocks.build_root_json([SwaggerPathAndParametersSchema])
+  it 'generates the path and parameters definition when there is only one path call' do
+    json = Swagger::Blocks.build_root_json([SwaggerPathAndParametersSchema1])
+
+    expect(json[:paths]).to include({
+      :"/stembolts" => hash_including({
+        get: hash_including({
+          summary: "A summary",
+          operationId: "getStembolts"
+        })
+      })
+    })
+
+    expect(json[:definitions]).to include({
+      "GetStemboltsParameters" => {
+        properties: {
+          param1: {type: :string},
+          param2: {type: :string, description: "Not param1"}
+        },
+        required: ["param1"]
+      }
+    })
+  end
+
+  it 'works when there are two path calls' do
+    json = Swagger::Blocks.build_root_json([SwaggerPathAndParametersSchema2])
 
     expect(json[:paths]).to include({
       :"/stembolts" => hash_including({

--- a/spec/lib/swagger_path_and_parameters_schema_spec.rb
+++ b/spec/lib/swagger_path_and_parameters_schema_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'swagger_path_and_parameters_schema' do
+
+  it 'generates the path and parameters definition' do
+    json = Swagger::Blocks.build_root_json([SwaggerPathAndParametersSchema])
+
+    expect(json[:paths]).to include({
+      :"/stembolts" => hash_including({
+        get: hash_including({
+          summary: "A summary",
+          operationId: "getStembolts"
+        })
+      })
+    })
+
+    expect(json[:definitions]).to include({
+      "GetStemboltsParameters" => {
+        properties: {
+          param1: {type: :string},
+          param2: {type: :string, description: "Not param1"}
+        },
+        required: ["param1"]
+      }
+    })
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,9 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+Dir[Rails.root.join('..', '..', 'spec', 'support', '**', '*.rb')].each { |f| require f unless f.ends_with?("_spec.rb") }
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/support/swagger_path_and_parameters_schema.rb
+++ b/spec/support/swagger_path_and_parameters_schema.rb
@@ -1,0 +1,37 @@
+module SwaggerPathAndParametersSchema
+  include Swagger::Blocks
+  include OpenStax::Swagger::SwaggerBlocksExtensions
+
+  swagger_root do
+    key :swagger, '2.0'
+  end
+
+  swagger_path_and_parameters_schema '/stembolts' do
+    operation :get do
+      key :summary, 'A summary'
+      key :operationId, 'getStembolts'
+      key :produces, [
+        'application/json'
+      ]
+      key :tags, [
+        'Stembolts'
+      ]
+      parameter do
+        key :name, :param1
+        key :in, :query
+        key :type, :string
+        key :required, true
+      end
+      parameter do
+        key :name, :param2
+        key :in, :query
+        key :type, :string
+        key :required, false
+        key :description, 'Not param1'
+      end
+      response 200 do
+        key :description, 'Success.'
+      end
+    end
+  end
+end

--- a/spec/support/swagger_path_and_parameters_schema_1.rb
+++ b/spec/support/swagger_path_and_parameters_schema_1.rb
@@ -1,4 +1,4 @@
-module SwaggerPathAndParametersSchema
+module SwaggerPathAndParametersSchema1
   include Swagger::Blocks
   include OpenStax::Swagger::SwaggerBlocksExtensions
 

--- a/spec/support/swagger_path_and_parameters_schema_2.rb
+++ b/spec/support/swagger_path_and_parameters_schema_2.rb
@@ -1,0 +1,42 @@
+module SwaggerPathAndParametersSchema2
+  include Swagger::Blocks
+  include OpenStax::Swagger::SwaggerBlocksExtensions
+
+  swagger_root do
+    key :swagger, '2.0'
+  end
+
+  swagger_path '/stembolts' do
+    operation :post do
+    end
+  end
+
+  swagger_path_and_parameters_schema '/stembolts' do
+    operation :get do
+      key :summary, 'A summary'
+      key :operationId, 'getStembolts'
+      key :produces, [
+        'application/json'
+      ]
+      key :tags, [
+        'Stembolts'
+      ]
+      parameter do
+        key :name, :param1
+        key :in, :query
+        key :type, :string
+        key :required, true
+      end
+      parameter do
+        key :name, :param2
+        key :in, :query
+        key :type, :string
+        key :required, false
+        key :description, 'Not param1'
+      end
+      response 200 do
+        key :description, 'Success.'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds `swagger_path_and_parameters_schema` that calls `swagger_path` but also calls `swagger_schema` with the parameters from the `swagger_path` call.  This lets developers generate a binding from this swagger_model that they can use to bind to the parameters in a controller call.